### PR TITLE
Remove hardcoded Twitter card image dimensions

### DIFF
--- a/config/install/metatag.metatag_defaults.node__osu_profile.yml
+++ b/config/install/metatag.metatag_defaults.node__osu_profile.yml
@@ -18,6 +18,4 @@ tags:
   twitter_cards_description: '[node:field_profile_biography]'
   twitter_cards_image: '[node:field_profile_image:twitter_300x157]'
   twitter_cards_image_alt: '[node:field_profile_image:alt]'
-  twitter_cards_image_height: '300'
-  twitter_cards_image_width: '157'
   twitter_cards_type: summary_large_image


### PR DESCRIPTION
The image height and width values for Twitter cards in metatag defaults have been removed from 'node__osu_profile' configuration. This change allows the settings to dynamically adapt to the size of the actual images used, which is more flexible and maintenance-free.