### PR TITLE
Update core version requirements

### DIFF
--- a/config/install/views.view.profile.yml
+++ b/config/install/views.view.profile.yml
@@ -727,7 +727,6 @@ display:
             vids:
               osu_organization: osu_organization
             anyall: ','
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/osu_profile.info.yml
+++ b/osu_profile.info.yml
@@ -2,7 +2,7 @@ name: "OSU Profile"
 description: "Adds OSU profile content type"
 package: OSU
 type: module
-version: 1.0.13
+version: 1.0.14
 core_version_requirement: ^10 || ^11
 dependencies:
  - auto_entitylabel:auto_entitylabel

--- a/osu_profile.info.yml
+++ b/osu_profile.info.yml
@@ -3,7 +3,7 @@ description: "Adds OSU profile content type"
 package: OSU
 type: module
 version: 1.0.13
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
  - auto_entitylabel:auto_entitylabel
  - osu_default_content:osu_default_content


### PR DESCRIPTION
Change core_version_requirement in osu_profile.info.yml from ^9 || ^10 to ^10 || ^11 to align with updated Drupal core versions. Also, remove an unused default_argument_skip_url parameter in profile view settings. This ensures compatibility with newer versions while cleaning up configuration.