### PR TITLE
Use focal_point for profile images with scaling and cropping

### DIFF
--- a/config/install/core.entity_form_display.node.osu_profile.default.yml
+++ b/config/install/core.entity_form_display.node.osu_profile.default.yml
@@ -15,12 +15,12 @@ dependencies:
     - field.field.node.osu_profile.field_profile_office_phone
     - field.field.node.osu_profile.field_profile_primary_title
     - field.field.node.osu_profile.field_profile_pronouns
-    - image.style.thumbnail
+    - image.style.x_large
     - node.type.osu_profile
   module:
     - address
     - field_group
-    - image
+    - focal_point
     - media_library
     - path
     - telephone
@@ -148,12 +148,14 @@ content:
       placeholder: ''
     third_party_settings: { }
   field_profile_image:
-    type: image_image
+    type: image_focal_point
     weight: 14
     region: content
     settings:
       progress_indicator: throbber
-      preview_image_style: thumbnail
+      preview_image_style: x_large
+      preview_link: true
+      offsets: '50,50'
     third_party_settings: { }
   field_profile_last_name:
     type: string_textfield

--- a/config/install/image.style.profile_image.yml
+++ b/config/install/image.style.profile_image.yml
@@ -1,14 +1,22 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: profile_image
 label: 'Profile Image'
 effects:
-  735fa0e3-4235-412a-afb1-80a683bb8edf:
-    uuid: 735fa0e3-4235-412a-afb1-80a683bb8edf
-    id: image_scale
-    weight: 2
+  b7ddba36-70cc-4fec-a9c6-f22ab48e74b7:
+    uuid: b7ddba36-70cc-4fec-a9c6-f22ab48e74b7
+    id: focal_point_scale_and_crop
+    weight: -10
     data:
-      width: null
-      height: 250
-      upscale: true
+      width: 600
+      height: 600
+      crop_type: focal_point
+  a7fe1ee5-a8d5-42bb-9655-c818ca852d86:
+    uuid: a7fe1ee5-a8d5-42bb-9655-c818ca852d86
+    id: image_convert
+    weight: -9
+    data:
+      extension: webp

--- a/config/install/views.view.profile.yml
+++ b/config/install/views.view.profile.yml
@@ -432,7 +432,7 @@ display:
           exclude: false
           alter:
             alter_text: true
-            text: "<div class=\"osu-bg-page-alt-1 osu-img-full osu-min-h-600 osu-shadow rounded-bottom\">\r\n  {{ field_profile_image }}\r\n  <div class=\"p-3\">\r\n    <h2 class=\"fw-bolder text-break\">\r\n      {{ title }}\r\n    </h2>\r\n    {{ field_profile_pronouns }}\r\n    {{ field_profile_email }}\r\n    {{ field_profile_office_phone }}\r\n    {{ field_profile_address }}\r\n  </div>\r\n</div>"
+            text: "<div class=\"osu-bg-page-alt-1 osu-min-h-600 osu-shadow rounded-bottom\">\r\n  {{ field_profile_image }}\r\n  <div class=\"p-3\">\r\n    <h2 class=\"fw-bolder text-break\">\r\n      {{ title }}\r\n    </h2>\r\n    {{ field_profile_pronouns }}\r\n    {{ field_profile_email }}\r\n    {{ field_profile_office_phone }}\r\n    {{ field_profile_address }}\r\n  </div>\r\n</div>"
             make_link: false
             path: ''
             absolute: false

--- a/osu_profile.info.yml
+++ b/osu_profile.info.yml
@@ -9,3 +9,4 @@ dependencies:
  - osu_default_content:osu_default_content
  - address:address
  - field_group:field_group
+ - focal_point:focal_point

--- a/osu_profile.install
+++ b/osu_profile.install
@@ -10,7 +10,7 @@ use Drupal\pathauto\Entity\PathautoPattern;
 /**
  * Implements hook_install().
  */
-function osu_profile_install() {
+function osu_profile_install(): void {
   // Load default image by name to get uuid.
   $default_image_array = \Drupal::entityTypeManager()
     ->getStorage('file')
@@ -99,7 +99,7 @@ function osu_profile_update_9002(&$sandbox): TranslatableMarkup {
 /**
  * Add Metatag defaults and update display of name to an H1.
  */
-function osu_profile_update_9003(&$sandbox) {
+function osu_profile_update_9003(&$sandbox): TranslatableMarkup {
   $osu_profile_path = \Drupal::service('module_handler')
     ->getModule('osu_profile')
     ->getPath();
@@ -165,8 +165,19 @@ function osu_profile_update_9005(&$sandbox): TranslatableMarkup {
 /**
  * Update the profile image form widget to use Focal Point.
  */
-function osu_profiles_update_9006(&$sandbox): TranslatableMarkup {
-  $osu_profile_form_config = \Drupal::configFactory()
-    ->getEditable('core.entity_form_display.node.osu_profile.default');
+function osu_profile_update_9006(&$sandbox): TranslatableMarkup {
+  $osu_profile_form_config = \Drupal::configFactory()->getEditable('core.entity_form_display.node.osu_profile.default');
+  $form_content = $osu_profile_form_config->get('content');
+  $profile_image_field_settings = [
+    "progress_indicator" => "throbber",
+    "preview_image_style" => "x_large",
+    "preview_link" => TRUE,
+    "offsets" => '50,50',
+  ];
+  $form_content['field_profile_image']['type'] = 'image_focal_point';
+  $form_content['field_profile_image']['settings'] = $profile_image_field_settings;
+  $osu_profile_form_config->set('content', $form_content);
+  $osu_profile_form_config->save();
+
   return t('');
 }

--- a/osu_profile.install
+++ b/osu_profile.install
@@ -2,6 +2,7 @@
 
 use Drupal\Core\Config\FileStorage;
 use Drupal\Core\Entity\EntityStorageException;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\field\Entity\FieldConfig;
 use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\pathauto\Entity\PathautoPattern;
@@ -27,76 +28,40 @@ function osu_profile_install() {
 }
 
 /**
- * Make address field fields optional.
- *
+ * Add text break to fix issues with long names and emails.
  */
-function osu_profile_update_9005(&$sandbox) {
-  /** @var Drupal\field\Entity\FieldConfig $profile_address_field */
-  $profile_address_field = FieldConfig::loadByName('node', 'osu_profile', 'field_profile_address');
-  /** @var array $field_overrides */
-  $field_overrides = $profile_address_field->getSetting('field_overrides');
-  $address_field_updates = [
-    "addressLine1" => [
-      "override" => "optional",
-    ],
-    "postalCode" => [
-      "override" => "optional",
-    ],
-    "locality" => [
-      "override" => "optional",
-    ],
-    "administrativeArea" => [
-      "override" => "optional",
-    ],
-  ];
-  $field_overrides = array_merge($address_field_updates, $field_overrides);
-  $profile_address_field->setSetting('field_overrides', $field_overrides);
-  try {
-    $profile_address_field->save();
-    return t('Profile Address field is now optional.');
+function osu_profile_update_9001(&$sandbox): void {
+  // Add text break to title and email on the entity view display
+  $profile_layout = \Drupal::configFactory()
+    ->getEditable('core.entity_view_display.node.osu_profile.default');
+  $third_party_settings = $profile_layout->get('third_party_settings');
+  $components = $third_party_settings['layout_builder']['sections'][0]['components'];
+  foreach ($profile_layout->get('third_party_settings')['layout_builder']['sections'][0]['components'] as $key => &$component) {
+    if ($component['configuration']['id'] == 'field_block:node:osu_profile:title') {
+      $components[$key]['additional']['component_attributes']['block_content_attributes']['class'] = 'h2 fw-bolder osu-text-osuorange text-break';
+    }
+    else {
+      if ($component['configuration']['id'] == 'field_block:node:osu_profile:field_profile_email') {
+        $components[$key]['additional']['component_attributes']['block_content_attributes']['class'] = 'text-break';
+      }
+    }
   }
-  catch (EntityStorageException $e) {
-    \Drupal::logger('osu_profile')->error($e->getMessage());
-    return t('Something went wrong');
-  }
-}
+  $third_party_settings['layout_builder']['sections'][0]['components'] = $components;
+  $profile_layout->set('third_party_settings', $third_party_settings);
+  $profile_layout->save();
 
-/**
- * Add teaser display to profile content type.
- */
-function osu_profile_update_9004(&$sandbox) {
-  $osu_profile_path = \Drupal::service('module_handler')
-    ->getModule('osu_profile')
-    ->getPath();
-  $config_path = realpath($osu_profile_path . '/config/install');
-  /** @var \Drupal\Core\Config\FileStorage $file_source */
-  $file_source = new FileStorage($config_path);
-  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
-  $config_storage = \Drupal::service('config.storage');
-  $config_storage->write('core.entity_view_display.node.osu_profile.teaser', $file_source->read('core.entity_view_display.node.osu_profile.teaser'));
-}
-
-/**
- * Add Metatag defaults and update display of name to an H1.
- */
-function osu_profile_update_9003(&$sandbox) {
-  $osu_profile_path = \Drupal::service('module_handler')
-    ->getModule('osu_profile')
-    ->getPath();
-  $config_path = realpath($osu_profile_path . '/config/install');
-  /** @var \Drupal\Core\Config\FileStorage $file_source */
-  $file_source = new FileStorage($config_path);
-  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
-  $config_storage = \Drupal::service('config.storage');
-  $profile_metatag = $file_source->read('metatag.metatag_defaults.node__osu_profile');
-  $config_storage->write('metatag.metatag_defaults.node__osu_profile', $profile_metatag);
-  return t('Add default metatag for profile content type.');
+  // Update view display on profile view
+  $profile_view = \Drupal::configFactory()->getEditable('views.view.profile');
+  $view_display = $profile_view->get('display');
+  $view_display['default']['display_options']['fields']['nothing']['alter']['text'] = "<div class=\"p-3 osu-bg-page-alt-1 rounded-bottom\">\r\n  <h2 class=\"fw-bolder text-break\">\r\n    {{ title }}\r\n  </h2>\r\n  <p class=\"pb-4\">{{ field_profile_pronouns }}</p>\r\n  <p class=\"text-break\">{{ field_profile_email }}</p>\r\n  <p>{{ field_profile_office_phone }}</p>\r\n  <p>{{ field_profile_address }}</p>\r\n</div>";
+  $profile_view->set('display', $view_display);
+  $profile_view->save();
 }
 
 /**
  * Add new field to profile.
  */
-function osu_profile_update_9002(&$sandbox) {
+function osu_profile_update_9002(&$sandbox): TranslatableMarkup {
   $install_path = \Drupal::service('module_handler')
     ->getModule('osu_profile')
     ->getPath();
@@ -132,32 +97,76 @@ function osu_profile_update_9002(&$sandbox) {
 }
 
 /**
- * Add text break to fix issues with long names and emails.
+ * Add Metatag defaults and update display of name to an H1.
  */
-function osu_profile_update_9001(&$sandbox) {
-  // Add text break to title and email on entity view display
-  $profile_layout = \Drupal::configFactory()
-    ->getEditable('core.entity_view_display.node.osu_profile.default');
-  $third_party_settings = $profile_layout->get('third_party_settings');
-  $components = $third_party_settings['layout_builder']['sections'][0]['components'];
-  foreach ($profile_layout->get('third_party_settings')['layout_builder']['sections'][0]['components'] as $key => &$component) {
-    if ($component['configuration']['id'] == 'field_block:node:osu_profile:title') {
-      $components[$key]['additional']['component_attributes']['block_content_attributes']['class'] = 'h2 fw-bolder osu-text-osuorange text-break';
-    }
-    else {
-      if ($component['configuration']['id'] == 'field_block:node:osu_profile:field_profile_email') {
-        $components[$key]['additional']['component_attributes']['block_content_attributes']['class'] = 'text-break';
-      }
-    }
-  }
-  $third_party_settings['layout_builder']['sections'][0]['components'] = $components;
-  $profile_layout->set('third_party_settings', $third_party_settings);
-  $profile_layout->save();
+function osu_profile_update_9003(&$sandbox) {
+  $osu_profile_path = \Drupal::service('module_handler')
+    ->getModule('osu_profile')
+    ->getPath();
+  $config_path = realpath($osu_profile_path . '/config/install');
+  /** @var \Drupal\Core\Config\FileStorage $file_source */
+  $file_source = new FileStorage($config_path);
+  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
+  $config_storage = \Drupal::service('config.storage');
+  $profile_metatag = $file_source->read('metatag.metatag_defaults.node__osu_profile');
+  $config_storage->write('metatag.metatag_defaults.node__osu_profile', $profile_metatag);
+  return t('Add default metatag for profile content type.');
+}
 
-  // Update view display on profile view
-  $profile_view = \Drupal::configFactory()->getEditable('views.view.profile');
-  $view_display = $profile_view->get('display');
-  $view_display['default']['display_options']['fields']['nothing']['alter']['text'] = "<div class=\"p-3 osu-bg-page-alt-1 rounded-bottom\">\r\n  <h2 class=\"fw-bolder text-break\">\r\n    {{ title }}\r\n  </h2>\r\n  <p class=\"pb-4\">{{ field_profile_pronouns }}</p>\r\n  <p class=\"text-break\">{{ field_profile_email }}</p>\r\n  <p>{{ field_profile_office_phone }}</p>\r\n  <p>{{ field_profile_address }}</p>\r\n</div>";
-  $profile_view->set('display', $view_display);
-  $profile_view->save();
+/**
+ * Add the teaser display to the profile content type.
+ */
+function osu_profile_update_9004(&$sandbox): void {
+  $osu_profile_path = \Drupal::service('module_handler')
+    ->getModule('osu_profile')
+    ->getPath();
+  $config_path = realpath($osu_profile_path . '/config/install');
+  /** @var \Drupal\Core\Config\FileStorage $file_source */
+  $file_source = new FileStorage($config_path);
+  /** @var \Drupal\Core\Config\CachedStorage $config_storage */
+  $config_storage = \Drupal::service('config.storage');
+  $config_storage->write('core.entity_view_display.node.osu_profile.teaser', $file_source->read('core.entity_view_display.node.osu_profile.teaser'));
+}
+
+/**
+ * Make address field fields optional.
+ */
+function osu_profile_update_9005(&$sandbox): TranslatableMarkup {
+  /** @var Drupal\field\Entity\FieldConfig $profile_address_field */
+  $profile_address_field = FieldConfig::loadByName('node', 'osu_profile', 'field_profile_address');
+  /** @var array $field_overrides */
+  $field_overrides = $profile_address_field->getSetting('field_overrides');
+  $address_field_updates = [
+    "addressLine1" => [
+      "override" => "optional",
+    ],
+    "postalCode" => [
+      "override" => "optional",
+    ],
+    "locality" => [
+      "override" => "optional",
+    ],
+    "administrativeArea" => [
+      "override" => "optional",
+    ],
+  ];
+  $field_overrides = array_merge($address_field_updates, $field_overrides);
+  $profile_address_field->setSetting('field_overrides', $field_overrides);
+  try {
+    $profile_address_field->save();
+    return t('Profile Address field is now optional.');
+  }
+  catch (EntityStorageException $e) {
+    \Drupal::logger('osu_profile')->error($e->getMessage());
+    return t('Something went wrong');
+  }
+}
+
+/**
+ * Update the profile image form widget to use Focal Point.
+ */
+function osu_profiles_update_9006(&$sandbox): TranslatableMarkup {
+  $osu_profile_form_config = \Drupal::configFactory()
+    ->getEditable('core.entity_form_display.node.osu_profile.default');
+  return t('');
 }


### PR DESCRIPTION
Replaced the image_scale effect with focal_point_scale_and_crop for better control over image cropping and scaling. Updated the profile image style to include focal point dependency and ensured output in WebP format for optimized performance. Added focal_point module as a dependency in the module info file.